### PR TITLE
StatusCake: parseo de mensaje enviado por statusCake cuando detecta u…

### DIFF
--- a/services/hookService.js
+++ b/services/hookService.js
@@ -162,9 +162,16 @@ function processStatusCakeHook(req, token, callback) {
 /*
 * StatusCake event parsing
 */
-function parseStatusCakeEvent(req){
-  return "Hardcoded message for StatusCake";
-
+function parseStatusCakeEvent(req_body){
+  console.log("into parseStatusCakeEvent");
+  console.log("req_body: ", req_body);
+  return {
+    type: req_body.Status,
+    resource: req_body.URL,
+    token: req_body.Token,
+    name: req_body.Name,
+    statusCode: req_body.StatusCode
+  };
   //URL=http%3A%2F%2F4c57dc5d.ngrok.io&Token=e194b521c5b37e215f3deeb43cdc1da3&Name=n%20rok&StatusCode=404&Status=Down
 }
 


### PR DESCRIPTION
…n cambio en el estado de la aplicacion que esta monitoreando (no se pudo probar porque statuscake no enviaba las notificaciones a la webhook url, si bien detectaba los cambios de estado de la aplicacion)
